### PR TITLE
Overall stats of issues/ commits from github 

### DIFF
--- a/contributions.cfg
+++ b/contributions.cfg
@@ -14,5 +14,5 @@ newissues_delta = 1
 # weeks
 commits_delta = 1
 
-# space spearates list of labels to be considers as blockers
+# space spearated list of labels to be considered as blockers
 blocker_labels = blocker critical

--- a/contributions.cfg
+++ b/contributions.cfg
@@ -8,3 +8,4 @@ admin_password = admin
 token = 3fa4e1dfb11f3159274a10c609e9260736d0fea0
 newissues_delta = 1
 commits_delta = 7
+blocker_label = blocker

--- a/contributions.cfg
+++ b/contributions.cfg
@@ -3,6 +3,7 @@ plone_url = http://localhost:8080/Plone/
 datadir = ./var/contributor_data
 admin_user = admin
 admin_password = admin
+plone_package = Products.CMFPlone
 
 [github]
 token = 3fa4e1dfb11f3159274a10c609e9260736d0fea0

--- a/contributions.cfg
+++ b/contributions.cfg
@@ -6,6 +6,12 @@ admin_password = admin
 
 [github]
 token = 3fa4e1dfb11f3159274a10c609e9260736d0fea0
+
+# days
 newissues_delta = 1
-commits_delta = 7
+
+# weeks
+commits_delta = 1
+
+# space spearates list of labels to be considers as blockers
 blocker_labels = blocker critical

--- a/contributions.cfg
+++ b/contributions.cfg
@@ -6,3 +6,5 @@ admin_password = admin
 
 [github]
 token = 3fa4e1dfb11f3159274a10c609e9260736d0fea0
+newissues_delta = 1
+commits_delta = 7

--- a/contributions.cfg
+++ b/contributions.cfg
@@ -8,4 +8,4 @@ admin_password = admin
 token = 3fa4e1dfb11f3159274a10c609e9260736d0fea0
 newissues_delta = 1
 commits_delta = 7
-blocker_label = blocker
+blocker_labels = blocker critical

--- a/ploneorg/core/__init__.py
+++ b/ploneorg/core/__init__.py
@@ -2,3 +2,5 @@
 from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('ploneorg')
+
+HOMEPAGE_ID = 'homepage'

--- a/ploneorg/core/behaviors.py
+++ b/ploneorg/core/behaviors.py
@@ -35,51 +35,83 @@ class NameFromFullName(object):
 
 
 @provider(IFormFieldProvider)
-class IGithubStatistics(model.Schema):
+class IPloneStatistics(model.Schema):
     """Behavior for github statistics data
     """
 
     model.fieldset(
         'github',
-        label=_(u"Github Statistics"),
+        label=_(u'Plone Statistics'),
         fields=[
-            'gh_new_issues',
-            'gh_commits',
-            'gh_blockers',
-            'gh_pr_last_week',
-            'gh_needs_review',
+            'stats_provider',
+            'stats_countries',
+            'stats_languages',
+            'stats_downloads',
+            'stats_new_issues',
+            'stats_commits',
+            'stats_blockers',
+            'stats_pr_last_week',
+            'stats_needs_review',
         ]
     )
 
-    gh_new_issues = schema.Int(
+    stats_provider = schema.Int(
+        title=_(u'provider', default=u'Solution Provider'),
+        description=u'Number of solution providers',
+        default=0,
+        required=False,
+    )
+
+    stats_countries = schema.Int(
+        title=_(u'countries', default=u'Countries'),
+        description=u'Number of countries',
+        default=0,
+        required=False,
+    )
+
+    stats_languages = schema.Int(
+        title=_(u'languages', default=u'Languages'),
+        description=u'Number of languages',
+        default=0,
+        required=False,
+    )
+
+    stats_downloads = schema.Int(
+        title=_(u'downloads', default=u'Downloads'),
+        description=u'Todays downloads',
+        default=0,
+        required=False,
+    )
+
+    stats_new_issues = schema.Int(
         title=_(u'new_issues', default=u'New issues'),
         description=u'New issues in last 24h',
         default=0,
         required=False,
     )
 
-    gh_commits = schema.Int(
+    stats_commits = schema.Int(
         title=_(u'commits', default=u'Commits'),
         description=u'Commits this calender week',
         default=0,
         required=False,
     )
 
-    gh_blockers = schema.Int(
+    stats_blockers = schema.Int(
         title=_(u'blockers', default=u'Blockers'),
         description=u'Issues blocking release',
         default=0,
         required=False,
     )
 
-    gh_pr_last_week = schema.Int(
+    stats_pr_last_week = schema.Int(
         title=_(u'pr_last_week', default=u'New PR last week'),
         description=u'PR created last week',
         default=0,
         required=False,
     )
 
-    gh_needs_review = schema.Int(
+    stats_needs_review = schema.Int(
         title=_(u'needs_review', default=u'Needs review'),
         description=u'PR needing review',
         default=0,

--- a/ploneorg/core/behaviors.py
+++ b/ploneorg/core/behaviors.py
@@ -50,7 +50,7 @@ class IPloneStatistics(model.Schema):
             'stats_new_issues',
             'stats_commits',
             'stats_blockers',
-            'stats_pr_last_week',
+            'stats_pull_requests',
             'stats_needs_review',
         ]
     )
@@ -104,9 +104,9 @@ class IPloneStatistics(model.Schema):
         required=False,
     )
 
-    stats_pr_last_week = schema.Int(
-        title=_(u'pr_last_week', default=u'New PR last week'),
-        description=u'PR created last week',
+    stats_pull_requests = schema.Int(
+        title=_(u'pull_requests', default=u'New PR last week'),
+        description=u'Pull requests created last week',
         default=0,
         required=False,
     )

--- a/ploneorg/core/behaviors.py
+++ b/ploneorg/core/behaviors.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 from plone.app.content.interfaces import INameFromTitle
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from ploneorg.core import _
 from ploneorg.core.content.foundationmember import IFoundationMember
-from zope.component import adapts
-from zope.interface import implements
+from zope import schema
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import provider
 
 
 class INameFromFullName(INameFromTitle):
@@ -17,9 +22,9 @@ class INameFromFullName(INameFromTitle):
     """
 
 
+@implementer(INameFromFullName)
+@adapter(IFoundationMember)
 class NameFromFullName(object):
-    implements(INameFromFullName)
-    adapts(IFoundationMember)
 
     def __init__(self, context):
         self.context = context
@@ -27,3 +32,56 @@ class NameFromFullName(object):
     @property
     def title(self):
         return self.context.get_full_name()
+
+
+@provider(IFormFieldProvider)
+class IGithubStatistics(model.Schema):
+    """Behavior for github statistics data
+    """
+
+    model.fieldset(
+        'github',
+        label=_(u"Github Statistics"),
+        fields=[
+            'gh_new_issues',
+            'gh_commits',
+            'gh_blockers',
+            'gh_pr_last_week',
+            'gh_needs_review',
+        ]
+    )
+
+    gh_new_issues = schema.Int(
+        title=_(u'new_issues', default=u'New issues'),
+        description=u'New issues in last 24h',
+        default=0,
+        required=False,
+    )
+
+    gh_commits = schema.Int(
+        title=_(u'commits', default=u'Commits'),
+        description=u'Commits this calender week',
+        default=0,
+        required=False,
+    )
+
+    gh_blockers = schema.Int(
+        title=_(u'blockers', default=u'Blockers'),
+        description=u'Issues blocking release',
+        default=0,
+        required=False,
+    )
+
+    gh_pr_last_week = schema.Int(
+        title=_(u'pr_last_week', default=u'New PR last week'),
+        description=u'PR created last week',
+        default=0,
+        required=False,
+    )
+
+    gh_needs_review = schema.Int(
+        title=_(u'needs_review', default=u'Needs review'),
+        description=u'PR needing review',
+        default=0,
+        required=False,
+    )

--- a/ploneorg/core/browser/configure.zcml
+++ b/ploneorg/core/browser/configure.zcml
@@ -30,6 +30,7 @@
       name="view"
       for="ploneorg.core.content.homepage.IHomePage"
       class=".homepage.HomePage"
+      template="homepage.pt"
       permission="zope2.View"
       />
 

--- a/ploneorg/core/browser/homepage.pt
+++ b/ploneorg/core/browser/homepage.pt
@@ -70,7 +70,13 @@
 <div class="homepage">
   <div class="row">
     <div class="col-md-12">
-      <p class="large-paragraph"><strong>300</strong> solution providers in <strong>57</strong> countries developing <strong>40</strong> languages</p>
+      <p class="large-paragraph">
+            <strong tal:content="context/stats_provider">300</strong>
+            solution providers in
+            <strong  tal:content="context/stats_countries">57</strong>
+            countries developing
+            <strong tal:content="context/stats_languages">40</strong>
+            languages</p>
       <div class="boxed boxed-stripes">Get Plone <strong>4.2.1</strong>New Collections, Diazo Theming, HTML5 Support <a class="btn" href="#">Download now</a></div>
     </div>
   </div>
@@ -83,37 +89,37 @@
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Today's downloads</h3>
-            <p class="large-paragraph"><strong>102</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/stats_downloads">102</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>New tickets today</h3>
-            <p class="large-paragraph"><strong tal:content="context/gh_new_issues">82</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/stats_new_issues">82</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Commits last week</h3>
-            <p class="large-paragraph"><strong tal:content="context/gh_commits">12</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/stats_commits">12</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Release blockers</h3>
-            <p class="large-paragraph"><strong tal:content="context/gh_blockers">7</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/stats_blockers">7</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Open pull requests</h3>
-            <p class="large-paragraph"><strong tal:content="context/gh_pr_last_week">86</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/stats_pr_last_week">86</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Patches needing reviews</h3>
-            <p class="large-paragraph"><strong tal:content="context/gh_needs_review">3</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/stats_needs_review">3</strong></p>
           </div>
         </div>
       </div>

--- a/ploneorg/core/browser/homepage.pt
+++ b/ploneorg/core/browser/homepage.pt
@@ -89,31 +89,31 @@
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>New tickets today</h3>
-            <p class="large-paragraph"><strong>82</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/gh_new_issues">82</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Commits last week</h3>
-            <p class="large-paragraph"><strong>12</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/gh_commits">12</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Release blockers</h3>
-            <p class="large-paragraph"><strong>7</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/gh_blockers">7</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Open pull requests</h3>
-            <p class="large-paragraph"><strong>86</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/gh_pr_last_week">86</strong></p>
           </div>
         </div>
         <div class="col-md-2">
           <div class="boxed boxed-pill boxed-primary">
             <h3>Patches needing reviews</h3>
-            <p class="large-paragraph"><strong>3</strong></p>
+            <p class="large-paragraph"><strong tal:content="context/gh_needs_review">3</strong></p>
           </div>
         </div>
       </div>

--- a/ploneorg/core/browser/homepage.py
+++ b/ploneorg/core/browser/homepage.py
@@ -1,16 +1,11 @@
 # -*- coding: utf-8 -*-
 from Products.Five import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 from datetime import datetime
 from plone import api
 
 
 class HomePage(BrowserView):
-    index = ViewPageTemplateFile('homepage.pt')
-
-    def __call__(self):
-        return self.index()
 
     def get_events(self):
         pc = api.portal.get_tool('portal_catalog')

--- a/ploneorg/core/configure.zcml
+++ b/ploneorg/core/configure.zcml
@@ -1,16 +1,14 @@
 <configure
+    i18n_domain="ploneorg.core"
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
-    xmlns:i18n="http://namespaces.zope.org/i18n"
-    xmlns:plone="http://namespaces.plone.org/plone"
-    xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    i18n_domain="ploneorg.core">
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
+    xmlns:plone="http://namespaces.plone.org/plone">
 
   <include package=".browser" />
-
   <include file="permissions.zcml" />
-
   <include package="plone.app.dexterity" />
   <include package="plone.app.contenttypes" />
   <include package="jarn.jsi18n" />
@@ -18,51 +16,61 @@
   <include package="ploneorg.theme" />
 
   <adapter
-    factory=".userschemaextender.UserDataPanelExtender"
-    provides="plone.z3cform.fieldsets.interfaces.IFormExtender" />
+      factory=".userschemaextender.UserDataPanelExtender"
+      provides="plone.z3cform.fieldsets.interfaces.IFormExtender"
+  />
 
   <adapter
-    provides=".userschemaextender.IEnhancedUserDataSchema"
-    for="plone.app.layout.navigation.interfaces.INavigationRoot"
-    factory=".userschemaextender.EnhancedUserDataSchemaAdapter"
-    />
+      factory=".userschemaextender.EnhancedUserDataSchemaAdapter"
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      provides=".userschemaextender.IEnhancedUserDataSchema"
+  />
+
 
   <plone:behavior
-    title="Name from full name for foundation members"
-    description="Use the full name as name (basis for the id)"
-    provides=".behaviors.INameFromFullName"
-    factory=".behaviors.NameFromFullName"
-    for="ploneorg.core.content.foundationmember.IFoundationMember"
-    />
+      description="Use the full name as name (basis for the id)"
+      factory=".behaviors.NameFromFullName"
+      for="ploneorg.core.content.foundationmember.IFoundationMember"
+      provides=".behaviors.INameFromFullName"
+      title="Name from full name for foundation members"
+  />
+
+  <plone:behavior
+      description="Stores the Github Statistics Data"
+      for="ploneorg.core.content.homepage.IHomePage"
+      provides=".behaviors.IGithubStatistics"
+      title="Github Stats"
+  />
 
   <include package="collective.monkeypatcher" />
 
   <monkey:patch
-      description="Patch to change the fixed default resize dimensions of the member portrait"
       class="Products.PlonePAS.tools.membership.MembershipTool"
+      description="Patch to change the fixed default resize dimensions of the member portrait"
       original="changeMemberPortrait"
       replacement=".portrait.changeMemberPortrait"
-      />
+  />
 
   <monkey:patch
-      description="Patch to fix the converter when rendering ++widget++form.widgets.portrait/@@download in new p.a.users zc3.form portrait widgets"
       class="z3c.form.converter.TextLinesConverter"
+      description="Patch to fix the converter when rendering ++widget++form.widgets.portrait/@@download in new p.a.users zc3.form portrait widgets"
       original="toWidgetValue"
       replacement=".userschemaextender.toWidgetValueTextLinesFix"
-      />
+  />
 
   <genericsetup:importStep
-    name="ploneorg.core.setupstep"
-    title="ploneorg.core special import handlers"
-    description=""
-    handler="ploneorg.core.setuphandlers.setupVarious" />
+      description=""
+      handler="ploneorg.core.setuphandlers.setupVarious"
+      name="ploneorg.core.setupstep"
+      title="ploneorg.core special import handlers"
+  />
 
   <genericsetup:registerProfile
-      name="default"
-      title="ploneorg.core"
-      directory="profiles/default"
       description="Installs the ploneorg.core package"
+      directory="profiles/default"
+      name="default"
       provides="Products.GenericSetup.interfaces.EXTENSION"
-      />
+      title="ploneorg.core"
+  />
 
 </configure>

--- a/ploneorg/core/configure.zcml
+++ b/ploneorg/core/configure.zcml
@@ -36,10 +36,10 @@
   />
 
   <plone:behavior
-      description="Stores the Github Statistics Data"
+      description="Stores the Plone Statistics Data"
       for="ploneorg.core.content.homepage.IHomePage"
-      provides=".behaviors.IGithubStatistics"
-      title="Github Stats"
+      provides=".behaviors.IPloneStatistics"
+      title="Plone Stats"
   />
 
   <include package="collective.monkeypatcher" />

--- a/ploneorg/core/contributions.py
+++ b/ploneorg/core/contributions.py
@@ -20,7 +20,7 @@ debug_limit = None
 GITHUB_TIMEFORMAT = '%Y-%m-%dT%H:%M:%S%z'
 
 _GITHUB_FETCHES_BASE = ['issues', 'contributions', 'commits']
-OTHER_FETCHES = ['stackoverflow']
+OTHER_FETCHES = ['stackoverflow', 'pypi']
 ALL_FETCHES = _GITHUB_FETCHES_BASE + OTHER_FETCHES
 GITHUB_FETCHES = set(_GITHUB_FETCHES_BASE)
 
@@ -115,7 +115,8 @@ def write_data(config, base_dir, json_string):
 def fetch(config, args):
     data = {
         'github': {},
-        'stackoverflow': None
+        'stackoverflow': None,
+        'pypi': None,
     }
     try:
 
@@ -128,6 +129,8 @@ def fetch(config, args):
             )
         if 'stackoverflow' in args.fetch_specific:
             data['stackoverflow'] = fetch_stackoverflow(config)
+        if 'pypi' in args.fetch_specific:
+            data['pypi'] = fetch_pypi(config)
     except IOError:
         logger.exception('An IOError happend, probably a read timeout')
         exit(1)
@@ -345,6 +348,18 @@ def fetch_stackoverflow(config):
 
     logger.info('Done.')
     return stackoverflow_users
+
+
+def fetch_pypi(config):
+    logger.info('Fetch data from pypi...')
+    package = config.get('general', 'plone_package')
+    url = 'http://pypi.python.org/pypi/{0}/json'.format(package)
+    rq = requests.get(url)
+    if rq.status_code != 200:
+        logger.warn('Can not fetch url {0}'.format(url))
+        return
+    result = rq.json()
+    return result['info']['downloads']
 
 
 def _so_activity_for_user(stackoverflow, userid, member_id):

--- a/ploneorg/core/contributions.py
+++ b/ploneorg/core/contributions.py
@@ -175,7 +175,9 @@ def _fetch_github_commits_info(
     current_delta = delta_weeks
     if len(participation.all) < delta_weeks:
         current_delta = len(participation.all)
-    data['commits'] += sum(participation.all[-current_delta])
+    if data['commits'] < 0:
+        data['commits'] = 0
+    data['commits'] += sum(participation.all[-current_delta:])
 
 
 def _fetch_github_issue_info(
@@ -223,6 +225,7 @@ def _fetch_github_issue_info(
     )
 
     # FETCH BLOCKERS
+    data['blockers'] = 0
     for blocker_label in blocker_labels:
         # loop needed because afaik theres no OR search at Github
         issues_blockers = gh.search_issues(
@@ -266,11 +269,11 @@ def fetch_github(
             'expense': {},
             'end': None},
         'contributions': {},
-        'new_issues': 0,
-        'commits': 0,
-        'blockers': 0,
-        'pull_requests': 0,
-        'needs_review': 0,
+        'new_issues': -1,
+        'commits': -1,
+        'blockers': -1,
+        'pull_requests': -1,
+        'needs_review': -1,
         'unknown': []
     }
 

--- a/ploneorg/core/contributions.py
+++ b/ploneorg/core/contributions.py
@@ -148,7 +148,8 @@ def _fetch_github_contributor_info(gh, organization, data, current_limit):
         current_limit = new_limit
 
 
-def _fetch_github_issue_info(gh, organization, data, current_limit, since):
+def _fetch_github_issue_info(gh, organization, data, current_limit, since,
+                             blocker_label):
     issues = check_debug_limit(organization.get_issues(), 'issues')
     for issue in issues:
         if issue.pull_request:
@@ -157,6 +158,8 @@ def _fetch_github_issue_info(gh, organization, data, current_limit, since):
                 data['needs_review'] += 1
         if issue.created_at > since:
             data['new_issues'] += 1
+        # labels = issue.labels
+        # import ipdb; ipdb.set_trace()
 
         # Track # of requests used for the repo
         new_limit = gh.rate_limiting[0]
@@ -206,9 +209,17 @@ def fetch_github(
         _fetch_github_contributor_info(gh, organization, data, current_limit)
 
     if 'issues' in args.fetch_specific:
+        blocker_label = int(config.get('github', 'blocker_label'))
         ni_delta = int(config.get('github', 'newissues_delta'))
         since = datetime.datetime.now() - datetime.timedelta(ni_delta)
-        _fetch_github_issue_info(gh, organization, data, current_limit, since)
+        _fetch_github_issue_info(
+            gh,
+            organization,
+            data,
+            current_limit,
+            since,
+            blocker_label,
+        )
 
     data['rate_limits']['end_limit'] = current_limit
     logger.info('Done.')

--- a/ploneorg/core/profiles/default/types/homepage.xml
+++ b/ploneorg/core/profiles/default/types/homepage.xml
@@ -28,6 +28,7 @@
   <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
   <element value="plone.app.contenttypes.behaviors.richtext.IRichText"/>
   <element value="plone.app.versioningbehavior.behaviors.IVersionable" />
+  <element value="ploneorg.core.behaviors.IGithubStatistics" />
  </property>
  <property name="schema">ploneorg.core.content.homepage.IHomePage</property>
  <property name="model_source"></property>

--- a/ploneorg/core/profiles/default/types/homepage.xml
+++ b/ploneorg/core/profiles/default/types/homepage.xml
@@ -28,7 +28,7 @@
   <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
   <element value="plone.app.contenttypes.behaviors.richtext.IRichText"/>
   <element value="plone.app.versioningbehavior.behaviors.IVersionable" />
-  <element value="ploneorg.core.behaviors.IGithubStatistics" />
+  <element value="ploneorg.core.behaviors.IPloneStatistics" />
  </property>
  <property name="schema">ploneorg.core.content.homepage.IHomePage</property>
  <property name="model_source"></property>

--- a/ploneorg/core/setuphandlers.py
+++ b/ploneorg/core/setuphandlers.py
@@ -2,6 +2,7 @@
 from Products.CMFCore.utils import getToolByName
 from plone import api
 from plone.dexterity.utils import createContentInContainer
+from ploneorg.core import HOMEPAGE_ID
 
 import logging
 import transaction
@@ -71,16 +72,16 @@ def setupVarious(context):
     pproperties.icon_visibility = 'disabled'
 
     # Create homepage if not present
-    homepage = getattr(portal, 'homepage', False)
+    homepage = getattr(portal, HOMEPAGE_ID, False)
     if not homepage:
         homepage = createContentInContainer(
             portal,
-            'homepage',
-            title=u'homepage',
+            HOMEPAGE_ID,
+            title=unicode(HOMEPAGE_ID.capitalize()),
             checkConstraints=False)
         homepage.exclude_from_nav = True
         logger.info('Default homepage site setup successfully.')
 
-    portal.setDefaultPage('homepage')
+    portal.setDefaultPage(HOMEPAGE_ID)
 
     transaction.commit()


### PR DESCRIPTION
fetch information needed for the homepage from github using its api,
- [x] new commits since
- [x] new issues since
- [x] open PR
- [x] number of PR needs review 
- [x] number of blockers
- [x] number of todays downloads
- [x] create some kind of storage in plone
- [x] upload issue related information to plone 
- [x] write view code in order to display the values

wip until all is checked

Questions:
- I think we want this only for plone organization?
- whats the label we check for blockers? I suggest ``blocker`` - but this need to get unified for the whole organization.
- this creates a whole bunch of requests against github, we may need to check if we have to split this up.