### PR TITLE
make orgsize and ploneuse fields optional

### DIFF
--- a/ploneorg/core/content/foundationmember.py
+++ b/ploneorg/core/content/foundationmember.py
@@ -109,13 +109,14 @@ class IFoundationMember(Schema):
         title=_(u'Organization size'),
         description=_(
             u'Number of people in your organization. It\'s fine to estimate.'),
+        required=False
     )
 
     read_permission(ploneuse='ploneorg.core.foundationmember.view')
     ploneuse = RichText(
         title=_(u'Plone use'),
         description=_(u'How is Plone used by your organization?'),
-        required=True
+        required=False
     )
 
 


### PR DESCRIPTION
...otherwise when someone edits their Foundation Member object they get a validation error but don't see which fields are causing the error unless they think to click onto the Survey tab/fieldset.