### PR TITLE
Add custom url normalizer for plonerelease types

### DIFF
--- a/ploneorg/core/configure.zcml
+++ b/ploneorg/core/configure.zcml
@@ -25,6 +25,18 @@
       factory=".content.foundationmember.NameFromPersonNames"
       />
 
+  <adapter
+    for="ploneorg.core.content.plonerelease.IPloneRelease"
+    provides="ploneorg.core.content.plonerelease.INameFromVersion"
+    factory="ploneorg.core.content.plonerelease.NameFromVersion"
+    />
+
+  <adapter
+    for="ploneorg.core.content.plonerelease.IChooseMyOwnDamnName"
+    provides="plone.i18n.normalizer.interfaces.IUserPreferredURLNormalizer"
+    factory="ploneorg.core.content.plonerelease.VersionNumberURLNormalizer"
+    />
+
   <include package="collective.monkeypatcher" />
 
   <monkey:patch

--- a/ploneorg/core/content/plonerelease.py
+++ b/ploneorg/core/content/plonerelease.py
@@ -12,6 +12,7 @@ from plone.supermodel.model import Schema
 from ploneorg.core import _
 from ploneorg.core.vocabularies import platform_vocabulary
 from zope import schema
+from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import implements
@@ -98,7 +99,11 @@ class NameFromVersion(object):
 
     def __init__(self, context):
         self.context = context
-        alsoProvides(self.context.REQUEST, IChooseMyOwnDamnName)
+        request = getattr(context, "REQUEST", None)
+        if request is None or isinstance(request, basestring):
+            # Handle '<Special Object Used to Force Acquisition>' case
+            request = getRequest()
+        alsoProvides(request, IChooseMyOwnDamnName)
 
     @property
     def title(self):

--- a/ploneorg/core/profiles/default/types/plonerelease.xml
+++ b/ploneorg/core/profiles/default/types/plonerelease.xml
@@ -21,6 +21,7 @@
  <property name="add_permission">ploneorg.core.plonerelease.add</property>
  <property name="klass">ploneorg.core.content.plonerelease.PloneRelease</property>
  <property name="behaviors">
+    <element value="ploneorg.core.content.plonerelease.INameFromVersion"/>
  </property>
  <property name="schema">ploneorg.core.content.plonerelease.IPloneRelease</property>
  <property name="model_source"></property>

--- a/ploneorg/core/tests/test_content_types.py
+++ b/ploneorg/core/tests/test_content_types.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
+from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.dexterity.interfaces import IDexterityFTI
 from ploneorg.core.content.foundationmember import IFoundationMember
 from ploneorg.core.content.homepage import IHomePage
+from ploneorg.core.content.plonerelease import VersionNumberURLNormalizer
 from ploneorg.core.testing import PLONEORG_CORE_INTEGRATION_TESTING
-from zope.component import createObject
 from zope.component import queryUtility
+from zope.container.interfaces import INameChooser
 
 import unittest
 
@@ -60,3 +62,45 @@ class ContentTypesTest(unittest.TestCase):
         fti.global_allow = True
         self.portal.invokeFactory('homepage', 'home')
         self.assertTrue(IHomePage.providedBy(self.portal.home))
+
+
+class PloneReleaseTest(unittest.TestCase):
+
+    layer = PLONEORG_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        fti = queryUtility(IDexterityFTI, name='plonerelease')
+        fti.global_allow = True
+        api.content.create(container=self.portal, type='Folder', id='releases')
+        container = self.portal.releases
+        api.content.create(
+            container=container, type='plonerelease', id='release-1')
+        self.obj = container['release-1']
+
+    def _test_version_string(self, obj, version):
+        obj.version = version
+        chooser = INameChooser(self.portal)
+        name = chooser.chooseName(None, obj)
+        self.assertEqual(name, version)
+
+    def test_id_from_version_bugfix(self):
+        self._test_version_string(self.obj, '5.0.3')
+
+    def test_id_from_version_beta(self):
+        self._test_version_string(self.obj, '5.1b3')
+
+    def test_id_from_version_release_candidate(self):
+        self._test_version_string(self.obj, '5.2rc3')
+
+    def test_id_from_version_weird(self):
+        self._test_version_string(self.obj, '5.0.6.1')
+
+    def test_id_from_version_conflict(self):
+        self._test_version_string(self.obj, '5.0.6')
+        container = self.portal.releases
+        api.content.create(
+            container=container, type='plonerelease', id='release-2')
+        duplicate = container['release-2']
+        self._test_version_string(duplicate, '5.0.6-1')


### PR DESCRIPTION
Allows plonerelease objects to have ids that are version numbers, ie 5.0.6 instead of 5-0.6

Closes #216 

